### PR TITLE
修正Ai智能测试保存失败的问题

### DIFF
--- a/apps/ui_automation/serializers.py
+++ b/apps/ui_automation/serializers.py
@@ -801,7 +801,7 @@ class UiScheduledTaskSerializer(serializers.ModelSerializer):
 class AICaseSerializer(serializers.ModelSerializer):
     project = UiProjectSerializer(read_only=True)
     created_by = UserSerializer(read_only=True)
-    project_id = serializers.IntegerField(write_only=True)
+    project_id = serializers.IntegerField(write_only=True, required=False, allow_null=True)
 
     class Meta:
         model = AICase


### PR DESCRIPTION
AI智能测试 - 保存为用例 ，触发“保存失败”的错误。

<img width="3456" height="1516" alt="image" src="https://github.com/user-attachments/assets/49b0572a-868b-4dfa-8761-0d62bcc87ebc" />

原因是：一些模型参数未对齐

故：提交PR修复！

本地测试已OK。
<img width="3428" height="1444" alt="image" src="https://github.com/user-attachments/assets/f3141246-78f1-455e-919c-bea5bf6c1be3" />
