### PR TITLE
Release合并main：接口测试&用例评审模块优化

### DIFF
--- a/apps/reviews/serializers.py
+++ b/apps/reviews/serializers.py
@@ -128,6 +128,52 @@ class TestCaseReviewCreateSerializer(serializers.ModelSerializer):
         
         return review
 
+    def update(self, instance, validated_data):
+        # 弹出关系字段（write_only 的 ListField / IntegerField），单独处理，
+        # 否则默认 update 会把 template 整数 id 直接赋给 FK（触发 ValueError），
+        # 也会把 testcases/projects/reviewers 当普通属性 set，无法正确更新 M2M。
+        testcases_ids = validated_data.pop('testcases', None)
+        reviewers_ids = validated_data.pop('reviewers', None)
+        projects_ids = validated_data.pop('projects', None)
+        template_id = validated_data.pop('template', None)
+
+        # 普通字段交给默认逻辑（title/description/priority/deadline）
+        instance = super().update(instance, validated_data)
+
+        # 项目关联
+        if projects_ids is not None:
+            instance.projects.set(projects_ids)
+
+        # 模板关联（id -> ReviewTemplate 实例）
+        if template_id is not None:
+            try:
+                from .models import ReviewTemplate
+                instance.template = ReviewTemplate.objects.get(id=template_id)
+            except ReviewTemplate.DoesNotExist:
+                instance.template = None
+            instance.save()
+        elif template_id is None and 'template' in self.initial_data:
+            # 显式传 null/0 时清空模板
+            instance.template = None
+            instance.save()
+
+        # 测试用例
+        if testcases_ids is not None:
+            instance.testcases.set(testcases_ids)
+
+        # 评审人员（through=ReviewAssignment，需重建）
+        if reviewers_ids is not None:
+            instance.reviewassignment_set.all().delete()
+            from apps.users.models import User
+            for reviewer_id in reviewers_ids:
+                try:
+                    reviewer = User.objects.get(id=reviewer_id)
+                    ReviewAssignment.objects.create(review=instance, reviewer=reviewer)
+                except User.DoesNotExist:
+                    continue
+
+        return instance
+
 
 class ReviewTemplateCreateSerializer(serializers.ModelSerializer):
     default_reviewers = serializers.ListField(child=serializers.IntegerField(), write_only=True, required=False)

--- a/apps/testcases/views.py
+++ b/apps/testcases/views.py
@@ -38,26 +38,33 @@ class TestCaseListCreateView(generics.ListCreateAPIView):
     permission_classes = [permissions.IsAuthenticated]
     pagination_class = TestCasePagination
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['priority', 'test_type', 'project']
+    filterset_fields = ['priority', 'test_type']
     search_fields = ['title', 'description']
     ordering_fields = ['created_at', 'updated_at', 'priority']
     ordering = ['-created_at']
-    
+
     def get_serializer_class(self):
         if self.request.method == 'POST':
             return TestCaseCreateSerializer
         return TestCaseListSerializer
-    
+
     def get_queryset(self):
         user = self.request.user
         accessible_projects = get_user_accessible_projects(user)
-        return TestCase.objects.filter(
+        queryset = TestCase.objects.filter(
             project__in=accessible_projects
         ).select_related(
             'author', 'assignee', 'project'
         ).prefetch_related(
             'versions'
         ).distinct()
+        # 支持多项目过滤：project=1,2,3（单值 project=1 同样兼容）
+        project_param = self.request.query_params.get('project')
+        if project_param:
+            project_ids = [int(pid) for pid in project_param.split(',') if pid.strip().isdigit()]
+            if project_ids:
+                queryset = queryset.filter(project_id__in=project_ids)
+        return queryset
     
     def get_user_accessible_projects(self, user):
         """获取用户有权限访问的项目"""

--- a/frontend/src/locales/lang/en/api-testing.js
+++ b/frontend/src/locales/lang/en/api-testing.js
@@ -232,10 +232,16 @@ export default {
     messageError: '❌Error',
     clear: 'Clear',
     // Response
-    response: 'Response',
+    response: 'Response Info',
     responseBody: 'Body',
     responseHeaders: 'Headers',
     assertionResults: 'Assertion Results',
+    // Request Info
+    requestInfo: 'Request Info',
+    requestHeaders: 'Request Headers',
+    requestBody: 'Request Body',
+    noRequestHeaders: 'No request headers',
+    noRequestBody: 'No request body',
     // Assertions
     assertions: 'Assertions',
     addAssertion: 'Add Assertion',
@@ -268,7 +274,8 @@ export default {
       addRequest: 'Add Request',
       addSubCollection: 'Add Sub-collection',
       edit: 'Edit',
-      delete: 'Delete'
+      delete: 'Delete',
+      copy: 'Copy'
     },
     // Others
     newRequest: 'New Request',

--- a/frontend/src/locales/lang/en/review.js
+++ b/frontend/src/locales/lang/en/review.js
@@ -197,6 +197,7 @@ export default {
     priorityUrgent: 'Urgent',
     deadline: 'Deadline',
     deadlinePlaceholder: 'Select deadline',
+    deadlineRequired: 'Please select a deadline',
     description: 'Review Description',
     descriptionPlaceholder: 'Enter review description',
 
@@ -204,7 +205,9 @@ export default {
     selectTestcases: 'Select Test Cases',
     searchTestcases: 'Search test cases',
     selectTestcasesBtn: 'Select Test Cases',
-    emptyTestcasesTip: 'Please select test cases for review',
+    selectedTestcasesCount: '{count} test case(s) selected',
+    noTestcasesSelected: 'No test cases selected',
+    modifyTestcasesSelection: 'Modify',
 
     // Reviewers
     reviewers: 'Reviewers',

--- a/frontend/src/locales/lang/zh-cn/api-testing.js
+++ b/frontend/src/locales/lang/zh-cn/api-testing.js
@@ -271,16 +271,23 @@ export default {
     messageError: '❌错误',
     clear: '清除',
     // 响应
-    response: '响应',
+    response: '响应信息',
     responseBody: 'Body',
     responseHeaders: 'Headers',
     assertionResults: '断言结果',
+    // 请求信息
+    requestInfo: '请求信息',
+    requestHeaders: '请求头',
+    requestBody: '请求体',
+    noRequestHeaders: '无请求头',
+    noRequestBody: '无请求体',
     // 右键菜单
     contextMenu: {
       addRequest: '添加请求',
       addSubCollection: '添加子集合',
       edit: '编辑',
-      delete: '删除'
+      delete: '删除',
+      copy: '复制'
     },
     // 其他
     newRequest: '新建请求',

--- a/frontend/src/locales/lang/zh-cn/review.js
+++ b/frontend/src/locales/lang/zh-cn/review.js
@@ -197,6 +197,7 @@ export default {
     priorityUrgent: '紧急',
     deadline: '截止日期',
     deadlinePlaceholder: '请选择截止日期',
+    deadlineRequired: '请选择截止日期',
     description: '评审描述',
     descriptionPlaceholder: '请输入评审描述',
 
@@ -204,7 +205,9 @@ export default {
     selectTestcases: '选择用例',
     searchTestcases: '搜索用例',
     selectTestcasesBtn: '选择用例',
-    emptyTestcasesTip: '请选择要评审的测试用例',
+    selectedTestcasesCount: '已选择{count}条测试用例',
+    noTestcasesSelected: '暂无已选用例',
+    modifyTestcasesSelection: '修改选择',
 
     // Reviewers
     reviewers: '评审人员',

--- a/frontend/src/views/api-testing/InterfaceManagement.vue
+++ b/frontend/src/views/api-testing/InterfaceManagement.vue
@@ -43,10 +43,14 @@
             node-key="id"
             :expand-on-click-node="false"
             :default-expanded-keys="expandedKeys"
+            draggable
+            :allow-drag="allowDrag"
+            :allow-drop="allowDrop"
             @node-click="onNodeClick"
             @node-contextmenu="onNodeRightClick"
             @node-expand="onNodeExpand"
             @node-collapse="onNodeCollapse"
+            @node-drop="handleDrop"
           >
             <template #default="{ node, data }">
               <div class="tree-node">
@@ -70,11 +74,21 @@
                 </div>
 
                 <!-- 普通显示模式 -->
-                <span v-else class="node-label">{{ node.label }}</span>
+                <span v-else class="node-label" :title="node.label">{{ node.label }}</span>
 
                 <span v-if="data.type === 'request' && data.request_type !== 'WEBSOCKET'" class="method-tag" :class="(data.method || 'GET').toLowerCase()">
                   {{ data.method || 'GET' }}
                 </span>
+
+                <!-- 悬浮操作按钮：复制（仅接口）、删除 -->
+                <div class="node-actions" @click.stop>
+                  <el-tooltip v-if="data.type === 'request'" :content="$t('apiTesting.interface.contextMenu.copy')" placement="top">
+                    <el-button link size="small" :icon="CopyDocument" @click.stop="copyRequest(data)" />
+                  </el-tooltip>
+                  <el-tooltip :content="$t('apiTesting.interface.contextMenu.delete')" placement="top">
+                    <el-button link size="small" :icon="Delete" @click.stop="deleteNode(data)" />
+                  </el-tooltip>
+                </div>
               </div>
             </template>
           </el-tree>
@@ -669,78 +683,106 @@
               </div>
             </div>
 
-            <el-tabs v-model="responseActiveTab">
-              <el-tab-pane label="Body" name="body">
-                <div class="response-body">
-                  <div class="response-actions">
-                    <el-button-group>
-                      <el-button size="small" @click="formatResponse">{{ $t('apiTesting.interface.format') }}</el-button>
-                      <el-button size="small" @click="copyResponse">{{ $t('apiTesting.interface.copy') }}</el-button>
-                      <el-button size="small" @click="toggleJsonPathExtractor">
-                        {{ $t('apiTesting.interface.jsonPathExtract') }}
-                      </el-button>
-                    </el-button-group>
-                  </div>
-                  <div v-if="showJsonPathExtractor" class="jsonpath-extractor">
-                    <div class="jsonpath-input">
-                      <el-input
-                        v-model="jsonPathExpression"
-                        :placeholder="$t('apiTesting.interface.jsonPathExample')"
-                        size="small"
-                        @input="evaluateJsonPath"
+            <el-tabs v-model="resultActiveTab" class="result-tabs">
+              <!-- 一级 tab：响应信息 -->
+              <el-tab-pane :label="$t('apiTesting.interface.response')" name="response">
+                <el-tabs v-model="responseActiveTab" class="nested-tabs">
+                  <el-tab-pane label="Body" name="body">
+                    <div class="response-body">
+                      <div class="response-actions">
+                        <el-button-group>
+                          <el-button size="small" @click="formatResponse">{{ $t('apiTesting.interface.format') }}</el-button>
+                          <el-button size="small" @click="copyResponse">{{ $t('apiTesting.interface.copy') }}</el-button>
+                          <el-button size="small" @click="toggleJsonPathExtractor">
+                            {{ $t('apiTesting.interface.jsonPathExtract') }}
+                          </el-button>
+                        </el-button-group>
+                      </div>
+                      <div v-if="showJsonPathExtractor" class="jsonpath-extractor">
+                        <div class="jsonpath-input">
+                          <el-input
+                            v-model="jsonPathExpression"
+                            :placeholder="$t('apiTesting.interface.jsonPathExample')"
+                            size="small"
+                            @input="evaluateJsonPath"
+                          >
+                            <template #append>
+                              <el-button size="small" @click="copyJsonPathResult">{{ $t('apiTesting.interface.copyResult') }}</el-button>
+                            </template>
+                          </el-input>
+                        </div>
+                        <div v-if="jsonPathResult !== null" class="jsonpath-result">
+                          <strong>{{ $t('apiTesting.interface.extractResult') }}</strong>
+                          <pre>{{ jsonPathResult }}</pre>
+                        </div>
+                      </div>
+                      <div class="response-content" v-html="highlightedResponseBody"></div>
+                    </div>
+                  </el-tab-pane>
+
+                  <el-tab-pane label="Headers" name="headers">
+                    <div class="response-headers">
+                      <div v-for="(value, key) in (response.response_data?.headers || {})" :key="key" class="header-row">
+                        <strong>{{ key }}:</strong> {{ value }}
+                      </div>
+                    </div>
+                  </el-tab-pane>
+
+                  <el-tab-pane :label="$t('apiTesting.interface.assertionResults')" name="assertions" v-if="response.assertions_results && response.assertions_results.length > 0">
+                    <div class="assertions-results">
+                      <div
+                        v-for="(result, index) in response.assertions_results"
+                        :key="index"
+                        class="assertion-result-item"
+                        :class="{ 'passed': result.passed, 'failed': !result.passed }"
                       >
-                        <template #append>
-                          <el-button size="small" @click="copyJsonPathResult">{{ $t('apiTesting.interface.copyResult') }}</el-button>
-                        </template>
-                      </el-input>
+                        <div class="assertion-result-header">
+                          <el-tag :type="result.passed ? 'success' : 'danger'" size="small">
+                            {{ result.passed ? $t('apiTesting.interface.passed') : $t('apiTesting.interface.failed') }}
+                          </el-tag>
+                          <span class="assertion-name">{{ result.name }}</span>
+                        </div>
+                        <div class="assertion-result-details">
+                          <div class="result-row">
+                            <span class="label">{{ $t('apiTesting.interface.expected') }}</span>
+                            <span class="value">{{ formatAssertionValue(result.expected) }}</span>
+                          </div>
+                          <div class="result-row">
+                            <span class="label">{{ $t('apiTesting.interface.actual') }}</span>
+                            <span class="value">{{ formatAssertionValue(result.actual) }}</span>
+                          </div>
+                          <div class="result-row" v-if="result.error">
+                            <span class="label">{{ $t('apiTesting.interface.error') }}</span>
+                            <span class="value error">{{ result.error }}</span>
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                    <div v-if="jsonPathResult !== null" class="jsonpath-result">
-                      <strong>{{ $t('apiTesting.interface.extractResult') }}</strong>
-                      <pre>{{ jsonPathResult }}</pre>
-                    </div>
-                  </div>
-                  <div class="response-content" v-html="highlightedResponseBody"></div>
-                </div>
+                  </el-tab-pane>
+                </el-tabs>
               </el-tab-pane>
 
-              <el-tab-pane label="Headers" name="headers">
-                <div class="response-headers">
-                  <div v-for="(value, key) in (response.response_data?.headers || {})" :key="key" class="header-row">
-                    <strong>{{ key }}:</strong> {{ value }}
-                  </div>
+              <!-- 一级 tab：请求信息 -->
+              <el-tab-pane :label="$t('apiTesting.interface.requestInfo')" name="request">
+                <div class="header-row request-line">
+                  <strong>{{ response.request_data?.method }}</strong>
+                  <span class="request-url">{{ response.request_data?.url }}</span>
                 </div>
-              </el-tab-pane>
+                <el-tabs v-model="requestActiveTab" class="nested-tabs">
+                  <el-tab-pane label="Body" name="body">
+                    <div v-if="hasRequestBodyData" class="response-content">{{ formattedRequestBody }}</div>
+                    <div v-else class="empty-tip">{{ $t('apiTesting.interface.noRequestBody') }}</div>
+                  </el-tab-pane>
 
-              <el-tab-pane :label="$t('apiTesting.interface.assertionResults')" name="assertions" v-if="response.assertions_results && response.assertions_results.length > 0">
-                <div class="assertions-results">
-                  <div
-                    v-for="(result, index) in response.assertions_results"
-                    :key="index"
-                    class="assertion-result-item"
-                    :class="{ 'passed': result.passed, 'failed': !result.passed }"
-                  >
-                    <div class="assertion-result-header">
-                      <el-tag :type="result.passed ? 'success' : 'danger'" size="small">
-                        {{ result.passed ? $t('apiTesting.interface.passed') : $t('apiTesting.interface.failed') }}
-                      </el-tag>
-                      <span class="assertion-name">{{ result.name }}</span>
-                    </div>
-                    <div class="assertion-result-details">
-                      <div class="result-row">
-                        <span class="label">{{ $t('apiTesting.interface.expected') }}</span>
-                        <span class="value">{{ formatAssertionValue(result.expected) }}</span>
-                      </div>
-                      <div class="result-row">
-                        <span class="label">{{ $t('apiTesting.interface.actual') }}</span>
-                        <span class="value">{{ formatAssertionValue(result.actual) }}</span>
-                      </div>
-                      <div class="result-row" v-if="result.error">
-                        <span class="label">{{ $t('apiTesting.interface.error') }}</span>
-                        <span class="value error">{{ result.error }}</span>
+                  <el-tab-pane label="Headers" name="headers">
+                    <div v-if="Object.keys(response.request_data?.headers || {}).length > 0" class="response-headers">
+                      <div v-for="(value, key) in (response.request_data?.headers || {})" :key="key" class="header-row">
+                        <strong>{{ key }}:</strong> {{ value }}
                       </div>
                     </div>
-                  </div>
-                </div>
+                    <div v-else class="empty-tip">{{ $t('apiTesting.interface.noRequestHeaders') }}</div>
+                  </el-tab-pane>
+                </el-tabs>
               </el-tab-pane>
             </el-tabs>
           </div>
@@ -932,7 +974,7 @@
 <script setup>
 import { ref, reactive, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
-import { Plus, Folder, Document, MagicStick, Search, Close } from '@element-plus/icons-vue'
+import { Plus, Folder, Document, MagicStick, Search, Close, CopyDocument, Delete } from '@element-plus/icons-vue'
 import api from '@/utils/api'
 import KeyValueEditor from './components/KeyValueEditor.vue'
 import DataFactorySelector from '@/components/DataFactorySelector.vue'
@@ -957,7 +999,9 @@ const response = ref(null)
 const sending = ref(false)
 const saving = ref(false)
 const activeTab = ref('params')
+const resultActiveTab = ref('response')
 const responseActiveTab = ref('body')
+const requestActiveTab = ref('body')
 const showCreateCollectionDialog = ref(false)
 const showEditCollectionDialog = ref(false)
 const showContextMenu = ref(false)
@@ -1105,13 +1149,16 @@ const loadCollections = async (projectId) => {
 
 const loadEnvironments = async (projectId) => {
   try {
-    const response = await api.get('/api-testing/environments/', {
-      params: {
-        project: projectId
-      }
-    })
+    // 不传递 project 参数，让后端返回所有可访问的环境（全局 + 当前用户项目），
+    // 否则 DjangoFilterBackend 的 project 过滤会把 project 为 null 的全局环境过滤掉。
+    const response = await api.get('/api-testing/environments/', {})
     // 后端可能返回分页格式 { results: [...] } 或直接返回数组
-    environments.value = response.data.results || response.data || []
+    const allEnvironments = response.data.results || response.data || []
+    // 过滤出全局环境 + 当前项目的局部环境
+    environments.value = allEnvironments.filter(env =>
+      env.scope === 'GLOBAL' ||
+      (env.scope === 'LOCAL' && (!projectId || env.project === projectId))
+    )
   } catch (error) {
     ElMessage.error('加载环境失败')
     console.error('加载环境失败:', error)
@@ -1427,10 +1474,7 @@ const editNode = () => {
   }
 }
 
-const deleteNode = () => {
-  if (!rightClickedNode.value) return
-
-  const node = rightClickedNode.value
+const deleteNode = (node = rightClickedNode.value) => {
   if (!node) {
     ElMessage.warning('无法删除此节点')
     return
@@ -1466,6 +1510,53 @@ const deleteNode = () => {
   })
 }
 
+const copyRequest = async (node) => {
+  if (!node || node.type !== 'request') return
+  try {
+    const { data } = await api.get(`/api-testing/requests/${node.id}/`)
+    const payload = { ...data }
+    delete payload.id
+    delete payload.created_at
+    delete payload.updated_at
+    delete payload.created_by
+    payload.name = `${data.name} (副本)`
+    // collection 保持原值 → 复制到同一集合下
+    await api.post('/api-testing/requests/', payload)
+    ElMessage.success('复制成功')
+    await loadCollections(selectedProject.value)
+  } catch (error) {
+    ElMessage.error('复制失败')
+    console.error('复制失败:', error)
+  }
+}
+
+// 仅接口节点可拖拽（集合不可拖，避免改动集合树结构）
+const allowDrag = (node) => node.data.type === 'request'
+
+// 仅允许把接口“放进”某个集合节点，不实现同集合内 prev/next 重排持久化
+const allowDrop = (draggingNode, dropNode, type) =>
+  type === 'inner' && dropNode?.data?.type === 'collection'
+
+const handleDrop = async (draggingNode, dropNode) => {
+  const requestId = draggingNode.data.id
+  const targetCollectionId = dropNode.data.id
+  // 同集合：el-tree 已乐观移动，统一 reload 回到服务端真实状态
+  if (draggingNode.data.collection === targetCollectionId) {
+    await loadCollections(selectedProject.value)
+    return
+  }
+  try {
+    await api.patch(`/api-testing/requests/${requestId}/`, { collection: targetCollectionId })
+    ElMessage.success('已移动到目标集合')
+  } catch (error) {
+    ElMessage.error('移动失败')
+    console.error('移动失败:', error)
+  } finally {
+    // el-tree 已乐观改了本地 collections，无论成败都用服务端状态覆盖，避免脏数据
+    await loadCollections(selectedProject.value)
+  }
+}
+
 const saveCollectionName = async () => {
   if (!editingNodeId.value || !editingNodeName.value.trim()) {
     cancelEdit()
@@ -1473,7 +1564,7 @@ const saveCollectionName = async () => {
   }
 
   try {
-    await api.put(`/api-testing/collections/${editingNodeId.value}/`, {
+    await api.patch(`/api-testing/collections/${editingNodeId.value}/`, {
       name: editingNodeName.value.trim()
     })
     ElMessage.success('保存成功')
@@ -1580,6 +1671,25 @@ const responseBody = computed(() => {
     }
   } catch (e) {
     return response.value.response_data?.body || ''
+  }
+})
+
+// 请求信息（执行后服务端返回的真实请求快照，已做变量解析）
+const hasRequestBodyData = computed(() => {
+  const body = response.value?.request_data?.body
+  if (body === null || body === undefined || body === '') return false
+  if (typeof body === 'object' && Object.keys(body).length === 0) return false
+  return true
+})
+
+const formattedRequestBody = computed(() => {
+  const body = response.value?.request_data?.body
+  if (body === null || body === undefined || body === '') return ''
+  if (typeof body === 'string') return body
+  try {
+    return JSON.stringify(body, null, 2)
+  } catch (e) {
+    return String(body)
   }
 })
 
@@ -1988,7 +2098,7 @@ const updateCollection = async () => {
   }
 
   try {
-    await api.put(`/api-testing/collections/${editCollectionForm.id}/`, editCollectionForm)
+    await api.patch(`/api-testing/collections/${editCollectionForm.id}/`, editCollectionForm)
     ElMessage.success('更新成功')
     await loadCollections(selectedProject.value)
     showEditCollectionDialog.value = false
@@ -2717,6 +2827,18 @@ const useLocalVariableCategories = () => {
   flex: 1;
   overflow: auto;
   padding: 10px;
+  min-width: 0;
+}
+
+/* el-tree 节点内容行：打断 min-content 宽度向上传播，
+   否则长接口名会让整行撑宽、把复制/删除按钮挤出可视区 */
+.collection-tree :deep(.el-tree-node__content) {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.collection-tree :deep(.el-tree-node__content > .el-tree-node__label) {
+  display: none;
 }
 
 /* 树节点样式 */
@@ -2725,22 +2847,51 @@ const useLocalVariableCategories = () => {
   align-items: center;
   gap: 8px;
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
   padding: 4px 0;
 }
 
 .tree-node .el-icon {
   font-size: 16px;
   color: #606266;
+  flex-shrink: 0;
 }
 
 .node-label {
   flex: 1;
+  min-width: 0;
   font-size: 14px;
   color: #303133;
   transition: color 0.2s;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tree-node:hover .node-label {
+  color: #409eff;
+}
+
+/* 悬浮操作按钮：默认隐藏，悬浮节点时显示 */
+.node-actions {
+  margin-left: auto;
+  flex-shrink: 0;
+  display: none;
+  align-items: center;
+  gap: 2px;
+}
+
+.tree-node:hover .node-actions {
+  display: flex;
+}
+
+.node-actions .el-button {
+  padding: 2px;
+  color: #909399;
+}
+
+.node-actions .el-button:hover {
   color: #409eff;
 }
 
@@ -2764,6 +2915,7 @@ const useLocalVariableCategories = () => {
   display: inline-block;
   min-width: 40px;
   text-align: center;
+  flex-shrink: 0;
 }
 
 .method-tag.get {
@@ -3286,6 +3438,57 @@ const useLocalVariableCategories = () => {
 
 .header-row:last-child {
   border-bottom: none;
+}
+
+/* 响应区域：一级 tab（响应信息 / 请求信息）切换，内部二级 tab 细分 */
+.result-tabs {
+  margin-top: 4px;
+  padding: 0 20px 20px;
+}
+
+.result-tabs :deep(.el-tabs__header) {
+  margin: 0 0 12px;
+}
+
+/* 嵌套的二级 tabs：去除默认大间距，紧贴上级 tab 内 */
+.nested-tabs :deep(.el-tabs__header) {
+  margin: 0 0 8px;
+}
+
+/* 请求行（方法 + URL） */
+.request-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: #ecf5ff;
+  border-radius: 6px;
+  border: 1px solid #d9ecff;
+  margin-bottom: 8px;
+}
+
+.request-line strong {
+  color: #409eff;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  flex-shrink: 0;
+}
+
+.request-url {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 13px;
+  word-break: break-all;
+  color: #303133;
+  min-width: 0;
+}
+
+/* 空数据提示 */
+.empty-tip {
+  padding: 24px 16px;
+  color: #909399;
+  font-size: 13px;
+  text-align: center;
+  background: #f8f9fa;
+  border-radius: 6px;
 }
 
 /* 代码编辑器 */
@@ -4161,6 +4364,7 @@ const useLocalVariableCategories = () => {
   display: inline-block;
   min-width: 40px;
   text-align: center;
+  flex-shrink: 0;
 }
 
 .method-tag.get {

--- a/frontend/src/views/reviews/ReviewForm.vue
+++ b/frontend/src/views/reviews/ReviewForm.vue
@@ -47,7 +47,7 @@
             </el-form-item>
           </el-col>
           <el-col :span="12">
-            <el-form-item :label="$t('reviewForm.deadline')">
+            <el-form-item :label="$t('reviewForm.deadline')" prop="deadline">
               <el-date-picker
                 v-model="form.deadline"
                 type="datetime"
@@ -71,32 +71,29 @@
         <el-form-item :label="$t('reviewForm.selectTestcases')" prop="testcases">
           <div class="testcase-selector">
             <div class="search-bar">
-              <el-input
-                v-model="testcaseSearch"
-                :placeholder="$t('reviewForm.searchTestcases')"
-                @input="searchTestcases"
-                clearable
+              <el-button
+                type="primary"
+                plain
+                :disabled="!form.projects || form.projects.length === 0"
+                @click="showTestcaseSelector"
               >
-                <template #prefix>
-                  <el-icon><Search /></el-icon>
-                </template>
-              </el-input>
-              <el-button type="primary" @click="showTestcaseSelector">{{ $t('reviewForm.selectTestcasesBtn') }}</el-button>
-            </div>
-
-            <div class="selected-testcases">
-              <el-tag
-                v-for="testcase in selectedTestcases"
-                :key="testcase.id"
-                closable
-                @close="removeTestcase(testcase.id)"
-                class="testcase-tag"
+                {{ $t('reviewForm.selectTestcasesBtn') }}
+              </el-button>
+              <span class="testcase-selection-tip">
+                {{
+                  selectedTestcases.length > 0
+                    ? $t('reviewForm.selectedTestcasesCount', { count: selectedTestcases.length })
+                    : $t('reviewForm.noTestcasesSelected')
+                }}
+              </span>
+              <el-button
+                v-if="selectedTestcases.length > 0"
+                link
+                type="primary"
+                @click="showTestcaseSelector"
               >
-                {{ testcase.title }}
-              </el-tag>
-              <div v-if="selectedTestcases.length === 0" class="empty-tip">
-                {{ $t('reviewForm.emptyTestcasesTip') }}
-              </div>
+                {{ $t('reviewForm.modifyTestcasesSelection') }}
+              </el-button>
             </div>
           </div>
         </el-form-item>
@@ -136,7 +133,7 @@
         <el-input
           v-model="testcaseSearchInDialog"
           :placeholder="$t('reviewForm.searchTestcases')"
-          @input="searchTestcasesInDialog"
+          @input="onTestcaseSearch"
           clearable
         >
           <template #prefix>
@@ -145,12 +142,16 @@
         </el-input>
 
         <el-table
-          :data="filteredTestcases"
-          @selection-change="handleTestcaseSelection"
+          ref="testcaseTableRef"
+          :data="testcases"
+          :row-key="row => row.id"
+          v-loading="testcaseLoading"
+          @select="onTestcaseSelect"
+          @select-all="onTestcaseSelectAll"
           max-height="400"
           class="testcase-table"
         >
-          <el-table-column type="selection" width="55" />
+          <el-table-column type="selection" width="55" reserve-selection />
           <el-table-column prop="title" :label="$t('reviewForm.testcaseTitle')" min-width="200" show-overflow-tooltip />
           <el-table-column prop="test_type" :label="$t('reviewForm.testType')" width="120" />
           <el-table-column prop="priority" :label="$t('reviewForm.priority')" width="100">
@@ -158,8 +159,24 @@
               <el-tag :class="`priority-tag ${row.priority}`">{{ getPriorityText(row.priority) }}</el-tag>
             </template>
           </el-table-column>
-          <el-table-column prop="author.username" :label="$t('reviewForm.author')" width="120" />
+          <el-table-column :label="$t('reviewForm.author')" width="120">
+            <template #default="{ row }">
+              {{ row.author?.username }}
+            </template>
+          </el-table-column>
         </el-table>
+
+        <div class="pagination-container">
+          <el-pagination
+            v-model:current-page="currentPage"
+            v-model:page-size="pageSize"
+            :page-sizes="[10, 20, 50, 100]"
+            :total="total"
+            layout="total, sizes, prev, pager, next, jumper"
+            @current-change="handlePageChange"
+            @size-change="handleSizeChange"
+          />
+        </div>
       </div>
       <template #footer>
         <el-button @click="testcaseSelectorVisible = false">{{ $t('reviewForm.cancel') }}</el-button>
@@ -170,11 +187,12 @@
 </template>
 
 <script setup>
-import { ref, reactive, onMounted, computed } from 'vue'
+import { ref, reactive, onMounted, computed, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 import { Search } from '@element-plus/icons-vue'
+import { debounce } from 'lodash-es'
 import api from '@/utils/api'
 
 const route = useRoute()
@@ -185,15 +203,23 @@ const isEdit = computed(() => !!route.params.id)
 const formRef = ref()
 const saving = ref(false)
 const testcaseSelectorVisible = ref(false)
-const testcaseSearch = ref('')
 const testcaseSearchInDialog = ref('')
 
 const projects = ref([])
 const projectUsers = ref([])
 const templates = ref([])
-const testcases = ref([])
-const selectedTestcases = ref([])
-const tempSelectedTestcases = ref([])
+const testcases = ref([])              // 当前页用例数据
+const selectedTestcases = ref([])      // 跨页累计选中的用例（完整对象）
+const testcaseTableRef = ref()
+
+// 用例弹框分页状态
+const currentPage = ref(1)
+const pageSize = ref(10)
+const total = ref(0)
+const testcaseLoading = ref(false)
+
+// 按 id 查已选用例，便于跨页判定与回填勾选
+const isSelected = (id) => selectedTestcases.value.some(tc => tc.id === id)
 
 const form = reactive({
   title: '',
@@ -209,16 +235,10 @@ const form = reactive({
 const rules = computed(() => ({
   title: [{ required: true, message: t('reviewForm.titleRequired'), trigger: 'blur' }],
   projects: [{ required: true, message: t('reviewForm.projectRequired'), trigger: 'change' }],
+  deadline: [{ required: true, message: t('reviewForm.deadlineRequired'), trigger: 'change' }],
   testcases: [{ required: true, message: t('reviewForm.testcasesRequired'), trigger: 'change' }],
   reviewers: [{ required: true, message: t('reviewForm.reviewersRequired'), trigger: 'change' }]
 }))
-
-const filteredTestcases = computed(() => {
-  if (!testcaseSearchInDialog.value) return testcases.value
-  return testcases.value.filter(tc =>
-    tc.title.toLowerCase().includes(testcaseSearchInDialog.value.toLowerCase())
-  )
-})
 
 const fetchProjects = async () => {
   try {
@@ -242,35 +262,84 @@ const fetchProjectUsers = async () => {
 }
 
 const fetchTestcases = async (projectIds) => {
+  // 未选项目则清空
+  if (!projectIds || projectIds.length === 0) {
+    testcases.value = []
+    total.value = 0
+    return
+  }
+
+  testcaseLoading.value = true
   try {
-    // 如果没有选择项目，清空用例列表
-    if (!projectIds || projectIds.length === 0) {
-      testcases.value = []
-      return
-    }
-
-    // 获取所有选中项目的用例
-    const promises = projectIds.map(projectId =>
-      api.get('/testcases/', { params: { project: projectId } })
-    )
-
-    const responses = await Promise.all(promises)
-    const allTestcases = []
-
-    responses.forEach(response => {
-      const cases = response.data.results || response.data || []
-      allTestcases.push(...cases)
+    const response = await api.get('/testcases/', {
+      params: {
+        project: projectIds.join(','),
+        page: currentPage.value,
+        page_size: pageSize.value,
+        search: testcaseSearchInDialog.value || undefined
+      }
     })
-
-    // 去重（基于用例ID）
-    const uniqueTestcases = allTestcases.filter((testcase, index, self) =>
-      index === self.findIndex(t => t.id === testcase.id)
-    )
-
-    testcases.value = uniqueTestcases
+    testcases.value = response.data.results || []
+    total.value = response.data.count || 0
+    // 数据回来后回填本页中已勾选的行
+    await nextTick()
+    restoreTableSelection()
   } catch (error) {
     console.error('Fetch testcases failed:', error)
+  } finally {
+    testcaseLoading.value = false
   }
+}
+
+// 回填当前页中已选中的行（跨页保留勾选状态）
+const restoreTableSelection = () => {
+  const table = testcaseTableRef.value
+  if (!table) return
+  testcases.value.forEach(tc => {
+    if (isSelected(tc.id)) {
+      table.toggleRowSelection(tc, true)
+    }
+  })
+}
+
+// 分页
+const handlePageChange = (val) => {
+  currentPage.value = val
+  fetchTestcases(form.projects)
+}
+
+const handleSizeChange = (val) => {
+  pageSize.value = val
+  currentPage.value = 1
+  fetchTestcases(form.projects)
+}
+
+// 搜索（防抖，回到第 1 页）
+const onTestcaseSearch = debounce(() => {
+  currentPage.value = 1
+  fetchTestcases(form.projects)
+}, 300)
+
+// 跨页勾选维护：单行勾选/取消
+const onTestcaseSelect = (selection, row) => {
+  if (selection.includes(row)) {
+    if (!isSelected(row.id)) selectedTestcases.value.push(row)
+  } else {
+    selectedTestcases.value = selectedTestcases.value.filter(tc => tc.id !== row.id)
+  }
+}
+
+// 跨页勾选维护：本页全选/全不选
+const onTestcaseSelectAll = (selection) => {
+  const selectedIds = new Set(selection.map(tc => tc.id))
+  // 先把本页里、但已不在 selection 的移除
+  selectedTestcases.value = selectedTestcases.value.filter(
+    tc => selectedIds.has(tc.id) || !testcases.value.some(t => t.id === tc.id)
+  )
+  // 再把本页里新选中的补上
+  selection.forEach(tc => {
+    if (!isSelected(tc.id)) selectedTestcases.value.push(tc)
+  })
 }
 
 const fetchTemplates = async (projectIds) => {
@@ -306,19 +375,24 @@ const fetchTemplates = async (projectIds) => {
 }
 
 const onProjectChange = (projectIds) => {
+  // 项目变化时重置分页与已选用例
+  currentPage.value = 1
+  testcaseSearchInDialog.value = ''
+  selectedTestcases.value = []
+
   if (projectIds && projectIds.length > 0) {
     fetchTestcases(projectIds)
     fetchTemplates(projectIds)
   } else {
     // 如果没有选择项目，清空相关数据
     testcases.value = []
+    total.value = 0
     templates.value = []
   }
 
   // 清空相关选择
   form.reviewers = []
   form.testcases = []
-  selectedTestcases.value = []
 }
 
 const showTestcaseSelector = () => {
@@ -327,21 +401,15 @@ const showTestcaseSelector = () => {
     return
   }
   testcaseSelectorVisible.value = true
-}
-
-const handleTestcaseSelection = (selection) => {
-  tempSelectedTestcases.value = selection
+  // 打开弹框时回到第 1 页并加载（保留已选中的用例，用于回填勾选）
+  currentPage.value = 1
+  fetchTestcases(form.projects)
 }
 
 const confirmTestcaseSelection = () => {
-  selectedTestcases.value = [...tempSelectedTestcases.value]
+  // selectedTestcases 在勾选时已实时维护，直接提交
   form.testcases = selectedTestcases.value.map(tc => tc.id)
   testcaseSelectorVisible.value = false
-}
-
-const removeTestcase = (id) => {
-  selectedTestcases.value = selectedTestcases.value.filter(tc => tc.id !== id)
-  form.testcases = selectedTestcases.value.map(tc => tc.id)
 }
 
 const onReviewersChange = () => {
@@ -369,10 +437,18 @@ const saveReview = async () => {
     await formRef.value.validate()
     saving.value = true
 
+    // 截止日期预处理：未选则传 null（字段可空）；有值则转 ISO-8601 格式，
+    // 避免 "YYYY-MM-DD HH:mm:ss"（空格分隔）被后端 DateTimeField 判为格式错误
+    let deadline = null
+    if (form.deadline) {
+      deadline = form.deadline.replace(' ', 'T')
+    }
+
     const data = {
       ...form,
       testcases: form.testcases,
       reviewers: form.reviewers,
+      deadline,
       // 确保包含 template 字段
       template: form.template || null
     }
@@ -483,14 +559,6 @@ const fetchReviewData = async (reviewId) => {
   }
 }
 
-const searchTestcases = () => {
-  // 搜索用例的逻辑
-}
-
-const searchTestcasesInDialog = () => {
-  // 在对话框中搜索用例的逻辑
-}
-
 onMounted(async () => {
   await fetchProjects()
   fetchProjectUsers() // 页面加载时就获取所有用户
@@ -534,31 +602,27 @@ onMounted(async () => {
 .testcase-selector {
   .search-bar {
     display: flex;
+    align-items: center;
     gap: 12px;
-    margin-bottom: 16px;
   }
 
-  .selected-testcases {
-    border: 1px solid #dcdfe6;
-    border-radius: 4px;
-    min-height: 80px;
-    padding: 8px;
-
-    .testcase-tag {
-      margin: 4px;
-    }
-
-    .empty-tip {
-      color: #909399;
-      text-align: center;
-      padding: 24px;
-    }
+  .testcase-selection-tip {
+    color: #606266;
+    font-size: 14px;
   }
 }
 
 .testcase-selector-content {
   .el-input {
     margin-bottom: 16px;
+  }
+
+  .pagination-container {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-top: 16px;
+    padding-top: 4px;
   }
 }
 


### PR DESCRIPTION
1.增加接口的一键复制、一键删除功能；
2.接口详情页面，底部增加请求信息打印；
3.修复接口管理-接口详情无法选择全局环境问题；
4.新建/编辑评审选择用例交互优化；
5.新建评审未选择日期设置为必填；
6.修复新建评审任务选择用例弹框不支持分页问题；
7.修复编辑评审保存时接口报错500；